### PR TITLE
[v1.7.3] Add in proper support for having Dock on the right

### DIFF
--- a/SpacesRenamer/Info.plist
+++ b/SpacesRenamer/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.2</string>
+	<string>1.7.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/spaces-renamer/Info.plist
+++ b/spaces-renamer/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.2</string>
+	<string>1.7.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/spaces-renamer/spacesRenamer.m
+++ b/spaces-renamer/spacesRenamer.m
@@ -13,7 +13,7 @@
 static char OVERRIDDEN_STRING;
 static char OVERRIDDEN_WIDTH;
 static char OFFSET;
-static char MOVED;
+static char NEW_X;
 static char TYPE;
 
 #define customNamesPlist [@"~/Library/Containers/com.alexbeals.spacesrenamer/com.alexbeals.spacesrenamer.plist" stringByExpandingTildeInPath]
@@ -212,12 +212,12 @@ ZKSwizzleInterface(_SRCALayer, CALayer, CALayer);
       arg1.origin.x = self.superlayer.frame.size.width / 2 - arg1.size.width / 2;
     } else {
       id possibleOffset = objc_getAssociatedObject(self.sublayers[textIndex], &OFFSET);
-      id didMove = objc_getAssociatedObject(self, &MOVED);
+      id newX = objc_getAssociatedObject(self, &NEW_X);
       // Only change the offsets once
-      if (possibleOffset && [possibleOffset isKindOfClass:[NSNumber class]] && (!didMove || ![didMove boolValue])) {
+      if (possibleOffset && [possibleOffset isKindOfClass:[NSNumber class]] && (newX == nil || [newX doubleValue] != arg1.origin.x)) {
         arg1.origin.x += [possibleOffset doubleValue];
 
-        assign(self, &MOVED, [NSNumber numberWithBool:YES]);
+        assign(self, &NEW_X, @(arg1.origin.x));
       }
     }
 

--- a/spaces-renamer/spacesRenamer.m
+++ b/spaces-renamer/spacesRenamer.m
@@ -186,42 +186,35 @@ static NSMutableArray *getNamesFromPlist() {
 
 ZKSwizzleInterface(_SRCALayer, CALayer, CALayer);
 @implementation _SRCALayer
-- (void)setBounds:(CGRect)arg1 {
-
-  return ZKOrig(void, arg1);
-}
 - (void)setFrame:(CGRect)arg1 {
   id possibleWidth = objc_getAssociatedObject(self, &OVERRIDDEN_WIDTH);
   if (possibleWidth && [possibleWidth isKindOfClass:[NSNumber class]] && self.class == NSClassFromString(@"CALayer")) {
     arg1.size.width = [possibleWidth doubleValue] + 20;
   }
+  
+  id possibleType = objc_getAssociatedObject(self, &TYPE);
+  if (possibleType == nil) {
+    return ZKOrig(void, arg1);
+  }
 
-  int textIndex = self.sublayers.lastObject.class == NSClassFromString(@"ECTextLayer")
-  ? (int)self.sublayers.count - 1
-  : -1;
+  int textIndex = (int)self.sublayers.count - 1;
+  possibleWidth = objc_getAssociatedObject(self.sublayers[textIndex], &OVERRIDDEN_WIDTH);
+  if (possibleWidth && [possibleWidth isKindOfClass:[NSNumber class]]) {
+    arg1.size.width = [possibleWidth doubleValue];
+  }
 
-  if (textIndex != -1) {
-    id possibleWidth = objc_getAssociatedObject(self.sublayers[textIndex], &OVERRIDDEN_WIDTH);
-    if (possibleWidth && [possibleWidth isKindOfClass:[NSNumber class]]) {
-      arg1.size.width = [possibleWidth doubleValue];
+  if ([possibleType isEqualToString:@"expanded"]) {
+    // Always just center in the parent view
+    arg1.origin.x = self.superlayer.frame.size.width / 2 - arg1.size.width / 2;
+  } else if ([possibleType isEqualToString:@"unexpanded"]) {
+    id possibleOffset = objc_getAssociatedObject(self.sublayers[textIndex], &OFFSET);
+    id newX = objc_getAssociatedObject(self, &NEW_X);
+    // Only change the offsets once
+    if (possibleOffset && [possibleOffset isKindOfClass:[NSNumber class]] && (newX == nil || [newX doubleValue] != arg1.origin.x)) {
+      arg1.origin.x += [possibleOffset doubleValue];
+
+      assign(self, &NEW_X, @(arg1.origin.x));
     }
-
-    id possibleType = objc_getAssociatedObject(self, &TYPE);
-    if (possibleType && [possibleType isEqualToString:@"expanded"]) {
-      // Always just center in the parent view
-      arg1.origin.x = self.superlayer.frame.size.width / 2 - arg1.size.width / 2;
-    } else {
-      id possibleOffset = objc_getAssociatedObject(self.sublayers[textIndex], &OFFSET);
-      id newX = objc_getAssociatedObject(self, &NEW_X);
-      // Only change the offsets once
-      if (possibleOffset && [possibleOffset isKindOfClass:[NSNumber class]] && (newX == nil || [newX doubleValue] != arg1.origin.x)) {
-        arg1.origin.x += [possibleOffset doubleValue];
-
-        assign(self, &NEW_X, @(arg1.origin.x));
-      }
-    }
-
-
   }
 
   return ZKOrig(void, arg1);


### PR DESCRIPTION
Fixes #56.

Before (would overlap in certain cases).
<img width="1048" alt="Screen Shot 2020-05-19 at 9 38 09 AM" src="https://user-images.githubusercontent.com/8919256/82354105-3bd27500-99b5-11ea-8168-5b07a7cf5c40.png">

After:
![image](https://user-images.githubusercontent.com/8919256/82716504-95080600-9c4c-11ea-9b5d-19446393443c.png)

Test case:
- Dock on bottom, left, right
- Transparency
- Expanded + unexpanded
- Swiping while unexpanded
- Swiping while expadned
