### PR TITLE
v1.7.4 - Fix regression with non-named Desktops

### DIFF
--- a/SpacesRenamer/Info.plist
+++ b/SpacesRenamer/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.3</string>
+	<string>1.7.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/spaces-renamer/Info.plist
+++ b/spaces-renamer/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.3</string>
+	<string>1.7.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/spaces-renamer/spacesRenamer.m
+++ b/spaces-renamer/spacesRenamer.m
@@ -186,34 +186,39 @@ static NSMutableArray *getNamesFromPlist() {
 
 ZKSwizzleInterface(_SRCALayer, CALayer, CALayer);
 @implementation _SRCALayer
+- (void)setBounds:(CGRect)arg1 {
+
+  return ZKOrig(void, arg1);
+}
 - (void)setFrame:(CGRect)arg1 {
   id possibleWidth = objc_getAssociatedObject(self, &OVERRIDDEN_WIDTH);
   if (possibleWidth && [possibleWidth isKindOfClass:[NSNumber class]] && self.class == NSClassFromString(@"CALayer")) {
     arg1.size.width = [possibleWidth doubleValue] + 20;
   }
-  
-  id possibleType = objc_getAssociatedObject(self, &TYPE);
-  if (possibleType == nil) {
-    return ZKOrig(void, arg1);
-  }
 
-  int textIndex = (int)self.sublayers.count - 1;
-  possibleWidth = objc_getAssociatedObject(self.sublayers[textIndex], &OVERRIDDEN_WIDTH);
-  if (possibleWidth && [possibleWidth isKindOfClass:[NSNumber class]]) {
-    arg1.size.width = [possibleWidth doubleValue];
-  }
+  int textIndex = self.sublayers.lastObject.class == NSClassFromString(@"ECTextLayer")
+  ? (int)self.sublayers.count - 1
+  : -1;
 
-  if ([possibleType isEqualToString:@"expanded"]) {
-    // Always just center in the parent view
-    arg1.origin.x = self.superlayer.frame.size.width / 2 - arg1.size.width / 2;
-  } else if ([possibleType isEqualToString:@"unexpanded"]) {
-    id possibleOffset = objc_getAssociatedObject(self.sublayers[textIndex], &OFFSET);
-    id newX = objc_getAssociatedObject(self, &NEW_X);
-    // Only change the offsets once
-    if (possibleOffset && [possibleOffset isKindOfClass:[NSNumber class]] && (newX == nil || [newX doubleValue] != arg1.origin.x)) {
-      arg1.origin.x += [possibleOffset doubleValue];
+  if (textIndex != -1) {
+    id possibleWidth = objc_getAssociatedObject(self.sublayers[textIndex], &OVERRIDDEN_WIDTH);
+    if (possibleWidth && [possibleWidth isKindOfClass:[NSNumber class]]) {
+      arg1.size.width = [possibleWidth doubleValue];
+    }
 
-      assign(self, &NEW_X, @(arg1.origin.x));
+    id possibleType = objc_getAssociatedObject(self, &TYPE);
+    if (possibleType && [possibleType isEqualToString:@"expanded"]) {
+      // Always just center in the parent view
+      arg1.origin.x = self.superlayer.frame.size.width / 2 - arg1.size.width / 2;
+    } else {
+      id possibleOffset = objc_getAssociatedObject(self.sublayers[textIndex], &OFFSET);
+      id newX = objc_getAssociatedObject(self, &NEW_X);
+      // Only change the offsets once
+      if (possibleOffset && [possibleOffset isKindOfClass:[NSNumber class]] && (newX == nil || [newX doubleValue] != arg1.origin.x)) {
+        arg1.origin.x += [possibleOffset doubleValue];
+
+        assign(self, &NEW_X, @(arg1.origin.x));
+      }
     }
   }
 


### PR DESCRIPTION
Caused issue with non-named Desktops misaligning with the last commit in v1.7.3. Back it out, maintain the NEW_X logic.